### PR TITLE
AlertScript for alert notification from Zabbix 2.x

### DIFF
--- a/zabbix/README.md
+++ b/zabbix/README.md
@@ -1,0 +1,127 @@
+# Zabbix Opsmatic Integration
+
+The Opsmatic Zabbix integration allows you to have Zabbix triggered events added to your Opsmatic feed.
+
+## Requirements
+
+The Opsmatic Zabbix integration is written in Ruby, it should run out of the box on Ruby 1.9 and upwards. If you're still running Ruby 1.8.7 you'll need to ensure `rubygems` and the `json` gems are available.
+
+## Configuration
+
+1. Check your Ruby install:
+
+    To check your Ruby version:
+
+    `ruby -v`
+
+    To install dependencies on Ubuntu:
+
+    `sudo apt-get install ruby-json rubygems`
+
+1. Install the `opsmatic-zabbix.rb` script in your Zabbix AlertScriptsPath directory on your Zabbix Server. See your Zabbix config documentation or zabbix_server.conf files for the exact location
+on your system. The default for 2.2 is `/usr/local/share/zabbix/alertscripts`. For our examples we'll place the script in `/usr/local/share/zabbix/alertscripts/opsmatic-zabbix.rb`
+
+1. Configure Zabbix Server to support Custom AlertScript media type. From your server's dashboard, go to `Administration | Media types`. Click `Create Media Type` button. Enter:
+
+    2. Name: `Opsmatic Notification`
+    2. Type: `Script`
+    2. Script name: `opsmatic-zabbix.rb`
+    2. Enabled: `on (check)`
+
+1. Create a user for Opsmatic alerts. Go to `Administration | Users`, Switch dropdown to `Users` and click `Create User`.
+
+    ### User Tab
+
+    2. Set the `Alias` to `Opsmatic` and `Name` to `Opsmatic Notifier`.
+    2. The `password` is any safe value you choose.
+    2. The `group` doesn't matter, but we use the default `No access to the frontend`.
+    2. The `Permissions` need to be read-write for any areas that will have the action triggered. In a default install, this is usually captured in a `Zabbix Super Admin` group, but you may have a custom setup.
+
+    ### Media Tab
+
+    2. Set the `type` to `Opsmatic Notification`.
+    2. Set `Send to` to your `Opsmatic API Token`.
+    2. Leave the other fields as default (24x7 active and all severities).
+    2. Make sure the `Status` is `enabled`.
+
+1. Configure Zabbix Server Action to initiate communication with Opsmatic. From your server's dashboard, go to `Configuration | Actions`. Select the `Event source` to be `Triggers`. Click `Create action` button. Enter:
+
+    ### Action Tab
+
+    ```
+    Name: Opsmatic Notifier
+
+    Default subject: Event: {HOST.HOST}: {TRIGGER.STATUS} : {TRIGGER.NAME}
+
+    Default message:
+        Trigger: {TRIGGER.NAME}
+        Trigger Status: {TRIGGER.STATUS}
+        Trigger Severity: {TRIGGER.SEVERITY}
+        Trigger NSeverity: {TRIGGER.NSEVERITY}
+        Trigger Expression: {TRIGGER.EXPRESSION}
+        Host Name: {HOST.NAME}
+        Host: {HOST.HOST}
+        Host IP: {HOST.IP}
+        Event ID: {EVENT.ID}
+        Event value: {EVENT.VALUE}
+        Event status: {EVENT.STATUS}
+        Event time: {EVENT.TIME}
+        Event date: {EVENT.DATE}
+        Event age: {EVENT.AGE}
+        Event acknowledgement: {EVENT.ACK.STATUS}
+        Event acknowledgement history: {EVENT.ACK.HISTORY}
+
+    Recovery message: on (check)
+
+    Recovery subject: Recovery: {HOST.HOST}: {TRIGGER.STATUS} : {TRIGGER.NAME}
+
+    Recovery message:
+        Trigger: {TRIGGER.NAME}
+        Trigger Status: {TRIGGER.STATUS}
+        Trigger NSeverity: {TRIGGER.NSEVERITY}
+        Trigger Severity: {TRIGGER.SEVERITY}
+        Trigger Expression: {TRIGGER.EXPRESSION}
+        Host Name: {HOST.NAME}
+        Host: {HOST.HOST}
+        Host IP: {HOST.IP}
+        Event ID: {EVENT.ID}
+        Event value: {EVENT.VALUE}
+        Event status: {EVENT.STATUS}
+        Event time: {EVENT.TIME}
+        Event date: {EVENT.DATE}
+        Event age: {EVENT.AGE}
+        Event acknowledgement: {EVENT.ACK.STATUS}
+        Event acknowledgement history: {EVENT.ACK.HISTORY}
+        Event Recovery ID: {EVENT.RECOVERY.ID}
+        Event Recovery value: {EVENT.RECOVERY.VALUE}
+        Event Recovery status: {EVENT.RECOVERY.STATUS}
+        Event Recovery time: {EVENT.RECOVERY.TIME}
+        Event Recovery date: {EVENT.RECOVERY.DATE}
+
+    Enabled: on (check)
+    ```
+
+    ### Conditions Tab (dependent on your Zabbix Version)
+
+    2. Set your conditions as following:
+
+        ```
+        (A) Maintenance status not in maintenance
+        (B) Trigger value = PROBLEM
+        (C) Trigger value = OK
+        ```
+    2. Make sure the type of calculation is (A) and (B or C)
+
+    ### Operations Tab
+
+    2. Create a new `Operation`, selecting defaults.
+    2. Operations type should be `Send message`.
+    2. For Send to Users, select your `Opsmatic user`.
+    2. Select `Opsmatic Notification` from the `Send only to` dropdown and be sure the `Default message`
+    checkbox is checked.
+    2. Click `Add` to add your new operation.
+
+1. You can check your configuration by looking at the Event list in your Zabbix dashboard, and
+clicking on an individual Event's timestamp (detail view). There should be no errors. You can
+also review your `zabbix_server.log` file for diagnostics. If you need additional help and logging
+information, you can change the `DEBUG_MODE` constant in the `opsmatic-zabbix.rb` script to `true`.

--- a/zabbix/opsmatic-zabbix.rb
+++ b/zabbix/opsmatic-zabbix.rb
@@ -1,0 +1,159 @@
+#!/usr/bin/env ruby
+#
+# opsmatic-zabbix.rb -- a script to relay zabbix triggered events to opsmatic
+#
+# You will need the following information:
+#
+# Opsmatic Organization Integration Token (Found in the Opsmatic dashboard under Org Settings | Team)
+#
+# See README.md for zabbix setup instructions
+#
+# Tested with all supported Rubies: 1.9.3, 2.0.0, 2.1.x
+
+if RUBY_VERSION =~ /^1.8/
+  require 'rubygems'
+  require 'net/https'
+end
+require 'optparse'
+require 'uri'
+require 'net/http'
+require 'json'
+require 'date'
+
+DEBUG_MODE    = false # set to true if debugging your Zabbix setup
+CONN_TIMEOUT  = 2  # http connection timeout (seconds)
+READ_TIMEOUT  = 2  # http read timeout (seconds)
+DEFAULT_API_URL = "https://api.opsmatic.com/webhooks/events"
+
+EVENT_TYPE_INDEX      = 0
+HOST_INDEX            = 1
+STATUS_INDEX          = 2
+TRIGGER_NAME_INDEX    = 3
+
+# map zabbix trigger severities to opsmatic statuses
+status_map = {
+  "OK"              => "ok",
+  "PROBLEM"         => "failure",
+  "Not Classified"  => "failure",
+  "Information"     => "ok",
+  "Warning"         => "warning",
+  "Average"         => "failure",
+  "High"            => "failure",
+  "Disaster"        => "failure"
+}
+
+options = {
+  :api_url => DEFAULT_API_URL
+}
+
+abort "Must supply three parameters: opsmatic-zabbix.rb to subject message" unless ARGV.length == 3
+
+## Get command line parameters
+# Message: Payload of data we parse
+message = ARGV.pop
+
+# Subject: Maps to basic metadata:
+#   Message Subject: "Event: {HOST.HOST}: {TRIGGER.STATUS} : {TRIGGER.NAME}"
+#   Recovery Subject: "Recovery: {HOST.HOST}: {TRIGGER.STATUS} : {TRIGGER.NAME}"
+subject = ARGV.pop
+
+# To: Opsmatic API Token
+to = ARGV.pop
+
+abort "Missing required parameters" unless message && subject && to
+
+# Debugging -- useful if you aren't certain if you have configured Zabbix correctly.
+# Uncomment and monitor your zabbix_server.log file.
+if DEBUG_MODE
+  $stderr.puts "To: #{to}"
+  $stderr.puts "Subject: #{subject}"
+  $stderr.puts "Message: #{message}"
+end
+
+# parse the subject
+subject_data = subject.split(':').map{ |t| t.strip }
+options[:token] = to
+data = {
+  :notification_type  => subject_data[EVENT_TYPE_INDEX],
+  :notification_source=> "host",
+  :notification_time  => Time.now.to_i,
+  :host               => subject_data[HOST_INDEX],
+  :status             => subject_data[STATUS_INDEX],
+  :trigger_name       => subject_data[TRIGGER_NAME_INDEX]
+}
+
+if options[:token].nil?
+  abort "Missing Opsmatic Token"
+end
+
+# parse the zabbix message body and capture each item into data
+message.each_line do |line|
+  key_value = line.split(':', 2)
+  key = key_value.first.strip.downcase
+  data[key] = key_value.last.strip
+end
+
+## postprocess the event
+# Process timestamp
+if data['event date']
+  parse_date = data['event date'].split('.').map(&:to_i)
+  parse_time = []
+  if data['event time']
+    parse_time = data['event time'].split(':').map(&:to_i)
+  end
+
+  data[:notification_time] = DateTime.new(parse_date[0], parse_date[1], parse_date[2],
+                                          parse_time[0], parse_time[1], parse_time[2]).strftime("%s").to_i
+end
+
+# Override Opsmatic URL
+if data['opsmatic api url']
+  options[:api_url] = data['opsmatic api url']
+end
+
+summary = sprintf "%s with '%s' on %s (%s)",
+  data[:notification_type],
+  data[:trigger_name],
+  data[:host],
+  (data['trigger severity'] || data[:status])
+
+event = {
+  :timestamp    => data[:notification_time],
+  :source       => "zabbix",
+  :type         => "notifications/zabbix",
+  :subject_type => "hostname",
+  :subject      => data[:host],
+  :summary      => summary,
+  :data         => data,
+  :category     => "notifications",
+  :status       => status_map[data[:status]]
+}
+
+# send the event
+composed_uri = "#{options[:api_url]}?token=#{options[:token]}"
+url = URI.parse(composed_uri)
+
+http = Net::HTTP.new(url.host, url.port)
+http.open_timeout = CONN_TIMEOUT
+http.read_timeout = READ_TIMEOUT
+http.use_ssl = (url.scheme == 'https')
+
+request = Net::HTTP::Post.new(url.request_uri)
+request["Content-Type"] = "application/json"
+request.body = [event].to_json
+
+$stderr.puts "URI: #{composed_uri} sending #{request.body}" if DEBUG_MODE
+
+begin
+  response = http.request(request)
+  if response.code != "202"
+    $stderr.puts "Got a #{response.code} from Opsmatic event service, notification wasn't recorded"
+    $stderr.puts response.body
+  else
+    $stderr.puts "Success: Notified #{composed_uri}: #{summary} (#{data[:status]})"
+  end
+rescue Timeout::Error
+  $stderr.puts "Timed out connecting to Opsmatic event service, notification wasn't recorded"
+rescue Exception => msg
+  $stderr.puts "An unhandled exception occured while posting event to Opsmatic event service: #{msg}"
+end


### PR DESCRIPTION
@mihasya Here is a Zabbix 2 AlertScript integration for Opsmatic. Setup in Zabbix is a little bit like falling down the rabbit hole, as integration with scripts assumes email-like interfaces. I've put together step-by-step instructions that worked for us in the readme. Tested in Zabbix 2.x, but there are a lot of dot releases out there, so there may be small tweaks. Uses pretty vanilla features and focus was on 2.2+.

Patterned after a clone of Nagios integration, so same requirements. 
